### PR TITLE
Use ExifReader As Fallback If Exifr fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/mime-types": "^3.0.1",
         "@xmldom/xmldom": "~0.9.8",
         "exifr": "^7.1.3",
+        "exifreader": "^4.31.2",
         "libheif-js": "^1.19.8",
         "mime": "^4.0.7",
         "rxjs": "~7.8.2",
@@ -7487,6 +7488,16 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
       "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="
+    },
+    "node_modules/exifreader": {
+      "version": "4.31.2",
+      "resolved": "https://registry.npmjs.org/exifreader/-/exifreader-4.31.2.tgz",
+      "integrity": "sha512-1NwFxGzoVyDDXpT4pw/gqQ10domJPOJFQHNhw7I4/qJZq1Rln0OlE7bfZLTM1gfxahvVV/pe9Dvsscda8h+27g==",
+      "hasInstallScript": true,
+      "license": "MPL-2.0",
+      "optionalDependencies": {
+        "@xmldom/xmldom": "^0.9.4"
+      }
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/mime-types": "^3.0.1",
     "@xmldom/xmldom": "~0.9.8",
     "exifr": "^7.1.3",
+    "exifreader": "^4.31.2",
     "libheif-js": "^1.19.8",
     "mime": "^4.0.7",
     "rxjs": "~7.8.2",

--- a/projects/ngx-advanced-img/package.json
+++ b/projects/ngx-advanced-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-advanced-img",
-  "version": "20.0.3",
+  "version": "20.0.4",
   "private": false,
   "license": "MIT",
   "author": "Brian Martinson <brian@brianmartinson.com> (https://brianmartinson.com/)",
@@ -29,6 +29,7 @@
     "@angular/core": ">= 15.0.0",
     "@xmldom/xmldom": ">= 0.8.10",
     "exifr": ">= 7.1.3",
+    "exifreader": ">= 4.31.2",
     "libheif-js": "^1.18.2",
     "mime": ">= 4.0.4",
     "rxjs": ">= 7.8.1"

--- a/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as exif from 'exifr';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as ExifReader from 'exifreader';
 import mime from 'mime';
 import { Observable, Subject } from 'rxjs';
 
@@ -255,8 +257,23 @@ export class NgxAdvancedImgBitmap {
             exifData,
           });
         })
-        .catch((error: any) => {
-          reject(error);
+        .catch(async (error: any) => {
+          console.warn('Failed to parse EXIF data with exifr, trying ExifReader...', error);
+          try {
+            const tags = ExifReader.load(await data.arrayBuffer());
+
+            const exifData = Object.keys(tags).reduce((acc: { [key: string]: any }, key) => {
+              acc[key] = tags[key].description;
+              return acc;
+            }, {} as { [key: string]: any });
+
+            resolve({
+              fileSize,
+              exifData,
+            });
+          } catch (error) {
+            reject(error);
+          }
         });
     });
   }


### PR DESCRIPTION
Exifr fails to load some HEIC images taken on an iPhone 16 Pro Max. Added the slower Exifreader library as a fallback.